### PR TITLE
Automated builds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,53 @@
+name: Build on push
+
+permissions:
+  packages: write
+
+on:
+    push:
+        branches:
+            - main
+            - master
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Set env variables
+        run: |
+          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        id: qemu
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+
+      - name: Run Docker buildx
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME-client:$BRANCH \
+                --output "type=registry" ./client/
+
+      - name: Run Docker buildx
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME-server:$BRANCH \
+                --output "type=registry" ./server/

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,14 +38,14 @@ jobs:
         uses: docker/setup-buildx-action@v1
         id: buildx
 
-      - name: Run Docker buildx
+      - name: Build client images
         run: |
                 docker buildx build \
                 --platform linux/amd64,linux/arm64 \
                 --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME-client:$BRANCH \
                 --output "type=registry" ./client/
 
-      - name: Run Docker buildx
+      - name: Build server images
         run: |
                 docker buildx build \
                 --platform linux/amd64,linux/arm64 \

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,49 @@
+name: Build on push
+
+permissions:
+  packages: write
+
+on: tag
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Set env variables
+        run: |
+          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        id: qemu
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+
+      - name: Build client images
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME-client:$TAG \
+                --output "type=registry" ./client/
+
+      - name: Build server images
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME-server:$TAG \
+                --output "type=registry" ./server/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:17-buster-slim as build
+FROM amd64/node:17-buster-slim as build
 
 WORKDIR /app
 
-COPY package.json .
+COPY package.json package-lock.json .
 
 RUN npm install
 
@@ -14,7 +14,7 @@ COPY public ./public
 
 RUN npm run build
 
-FROM nginx:1.17.8@sha256:380eb808e2a3b0dd954f92c1cae2f845e6558a15037efefcabc5b4e03d666d03
+FROM nginx:1.21.6
 
 EXPOSE 80
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -27,7 +27,8 @@ bitcoin_stream-*.tar
 /tmp
 
 # Logging files
-/log/
+/log/*
+!log/.gitkeep
 *.log
 
 .envrc

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,8 +9,7 @@ WORKDIR $APP_HOME
 
 EXPOSE 4000
 
-COPY mix.exs .
-COPY mix.lock .
+COPY mix.exs mix.lock .
 COPY bitcoinex ./bitcoinex
 
 RUN mix do deps.get


### PR DESCRIPTION
This automates the build and release of the Docker containers. They are now published to the GitHub container registry, and happen automatically.
I also fixed a bug: You forgot to include the log dir in the repo, so builds for anyone without it would fail.

I also integrated this app into @runcitadel and used these containers for it, so they are already tested (A demo instance is running at https://bitfeed.runcitadel.space).